### PR TITLE
pry-byebugをインストール

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :development, :test do
 
   # gem 'pry'
   gem 'pry-rails'
+  gem 'pry-byebug'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,9 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.8.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     puma (3.12.1)
@@ -188,6 +191,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
+  pry-byebug
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)


### PR DESCRIPTION
`next`でステップ実行もできるようになる
pry使うなら`./bin/docker-compose-attach web`をやるべき(↓のような`./bin/docker-compose-attach`ファイルがある場合)
```
#!/usr/bin/env bash

docker-compose up -d && docker attach $(docker-compose ps -q $1)
```

<u>ref</u>
https://docs.ruby-lang.org/ja/latest/method/Kernel/v/1.html